### PR TITLE
Bump default workers to 15 in e2e-playwright-dispatch

### DIFF
--- a/.github/workflows/e2e-playwright-dispatch.yml
+++ b/.github/workflows/e2e-playwright-dispatch.yml
@@ -53,7 +53,7 @@ on:
       workers:
         description: "Number of parallel Test System IO dispatch jobs"
         type: number
-        default: 8
+        default: 15
       playwright_project:
         description: "Playwright project name (passed to both dispatch-begin metadata and dispatch-run --project=)."
         type: string


### PR DESCRIPTION
## Summary
- Bumps the `workers` workflow_dispatch input default from 8 to 15 in `.github/workflows/e2e-playwright-dispatch.yml`, increasing Test System IO dispatch parallelism for manual runs.

Test run on staging cut Playwright's full duration from 16 min (master) to 11 min:
- Staging: https://staging-test-io.test.mattermost.com/reports/mattermost/master/49b7406/playwright-dispatch-test?gh_run_id=28995734589&gh_run_attempt=1
- Master: https://test-io.test.mattermost.com/reports/mattermost/master/49b7406/playwright-full-enterprise-master?gh_run_id=28986436368
